### PR TITLE
Potential fix for code scanning alert no. 1: Use of a known vulnerable action.

### DIFF
--- a/.github/workflows/updatemasterfeed.yml
+++ b/.github/workflows/updatemasterfeed.yml
@@ -67,7 +67,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Download all processed sources
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4.1.7
       with:
         path: processed-sources
 


### PR DESCRIPTION
Potential fix for [https://github.com/spydisec/spydithreatintel/security/code-scanning/1](https://github.com/spydisec/spydithreatintel/security/code-scanning/1)

To fix the problem, we need to update the version of the `actions/download-artifact` action from `v3` to `v4.1.7`. This will ensure that the workflow uses a version of the action that does not have the known vulnerabilities. The change is straightforward and involves modifying the version number in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
